### PR TITLE
mkimage: add firstboot.txt to boot partition

### DIFF
--- a/mkimage.sh
+++ b/mkimage.sh
@@ -96,7 +96,13 @@ devpts /dev/pts devpts gid=5,mode=620 0 0
 EOF
 
 echo "Copying kernel..."
-try cp prebuilt/zImage rootfs/boot
+cp prebuilt/zImage rootfs/boot
+
+cat > rootfs/boot/firstboot.txt << EOF
+EXPAND_ROOTFS=1
+MAKE_SWAP=1
+SWAP_SIZE=128
+EOF
 
 echo "Cleaning up..."
 cleanup


### PR DESCRIPTION
This is to expand the root partition automatically when using a Debian roofs tarball generated by dibs: https://github.com/ARMWorks/dibs
